### PR TITLE
fix bug 507

### DIFF
--- a/Source/Filters/Video/YPVideoFiltersVC.swift
+++ b/Source/Filters/Video/YPVideoFiltersVC.swift
@@ -134,13 +134,12 @@ public class YPVideoFiltersVC: UIViewController, IsMediaFilterVC {
                 switch session.status {
                 case .completed:
                     DispatchQueue.main.async {
-                        if let coverImage = self?.coverImageView.image,
-                            let asset = self?.inputVideo.asset {
-                            let resultVideo = YPMediaVideo(thumbnail: coverImage, videoURL: destinationURL, asset: asset)
+                        if let coverImage = self?.coverImageView.image{
+                            let resultVideo = YPMediaVideo(thumbnail: coverImage, videoURL: destinationURL, asset: self?.inputVideo.asset)
                             didSave(YPMediaItem.video(v: resultVideo))
                             self?.setupRightBarButtonItem()
                         } else {
-                            print("YPVideoFiltersVC -> Don't have coverImage or asset.")
+                            print("YPVideoFiltersVC -> Don't have coverImage.")
                         }
                     }
                 case .failed:


### PR DESCRIPTION
When video is created from camera the code creates `YPMediaVideo` without asset. please check `YYPPickerVC.swift` line 78-80`. Then we YPMediaVideo after trimming and change cover in `VideoFiltersVC` line 138-139`  and it will fail if there is no asset as we are check of asset is not nil. `let asset = self?.inputVideo.asset`.